### PR TITLE
fix: clear session_id from query params after saving GCP credentials

### DIFF
--- a/app.py
+++ b/app.py
@@ -290,6 +290,9 @@ def gcp_credentials_dialog(error=None):
 			localS.setItem("gcp_credentials", json.dumps(gcp_credentials), key="set_gcp_credentials")
 
 			st.success("GCP credentials saved successfully!")
+
+			if st.query_params.get("session_id"):
+				del st.query_params["session_id"]
 			st.rerun()
 		else:
 			st.stop()


### PR DESCRIPTION
This will ensure that the session ID from the old agent is not used with the newly connected agent.